### PR TITLE
lower minsdk version to 26

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -9,7 +9,7 @@ android {
 
     defaultConfig {
         applicationId = "com.xcarlost.firmwareflasher"
-        minSdk = 27
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/esptool-android/build.gradle.kts
+++ b/esptool-android/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     compileSdk = 34
 
     defaultConfig {
-        minSdk = 27
+        minSdk = 26
 
         ndk {
             abiFilters += listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")


### PR DESCRIPTION
According to https://apilevels.com/, 2.2% of Android users are using Android 8.0, API level 26. I have a colleague that had an Android 8 phone half a year ago.

After building this, uploading firmware still worked for me:
<img width="200" height="2408" alt="image" src="https://github.com/user-attachments/assets/96548c64-4506-4068-b264-c37815dc2dde" />
